### PR TITLE
Add screaming snake case, add and rework some settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 vim-themis/
 vim-vimlparser/
 vim-vimlint/
+
+# exclude vim tags
+tags

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-vim-camelsnek
-=============
+![GitHub Workflow Status](https://img.shields.io/github/workflow/status/nicwest/vim-camelsnek/test)
 
-[![Build Status](https://travis-ci.org/nicwest/vim-camelsnek.svg?branch=master)](https://travis-ci.org/nicwest/vim-camelsnek)
+# vim-camelsnek
 
 Convert between camel and snek case
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-[![Build Status](https://travis-ci.org/nicwest/vim-camelsnek.svg?branch=master)](https://travis-ci.org/nicwest/vim-camelsnek)
-
 vim-camelsnek
 =============
+
+[![Build Status](https://travis-ci.org/nicwest/vim-camelsnek.svg?branch=master)](https://travis-ci.org/nicwest/vim-camelsnek)
 
 Convert between camel and snek case
 
@@ -32,19 +32,19 @@ Settings
 " :CamelB -> :Camel
 let g:camelsnek_alternative_camel_commands = 1
 
-" This setting also changes the name of a command:
-" :Snek -> :Snake
-let g:camelsnek_i_am_an_old_fart_with_no_sense_of_humour_or_internet_culture = 0
+" Are you a stick in the mud? This setting also changes the name of two commands:
+" :Snek  -> :Snake
+" :Screm -> :SnakeCaps
+let g:camelsnek_no_fun_allowed = 0
 ```
 
 Tests
 -----
 
-To run the tests pull the [themis test
-suite](https://github.com/thinca/vim-themis) (you don't have to install it but
-you can if you want).
+To run the tests pull the [themis test suite](https://github.com/thinca/vim-themis)
+(you don't have to install it but you can if you want).
 
-```
+```shell
 git clone git@github.com:thinca/vim-themis.git
 ./vim-themis/bin/themis --reporter dot test
 ```
@@ -52,7 +52,7 @@ git clone git@github.com:thinca/vim-themis.git
 Alternatively you can use the Makefile in the root dir, which will clone the
 dependencies and run the tests and linter.
 
-```
+```shell
 make init
 make test
 make lint

--- a/README.md
+++ b/README.md
@@ -37,35 +37,13 @@ Settings
 " :CamelB -> :Camel
 let g:camelsnek_alternative_camel_commands = 1
 
-" Are you a stick in the mud? This setting also changes the name of two commands:
+" This setting also changes the name of two commands:
 " :Snek  -> :Snake
 " :Screm -> :Snakecaps
-let g:camelsnek_no_fun_allowed = 0
-```
+let g:camelsnek_i_am_an_old_fart_with_no_sense_of_humour_or_internet_culture = 0
+let g:camelsnek_no_fun_allowed = 0 " Shorter alias for the above.
 
-### Caveats
 
-This plugin appends to your `iskeyword` global setting by default in order to make
-editing kebab-case easier— in normal mode with this setting, you can place your cursor
-over a kebab-case word and convert it to any other available case. This may not be
-preferable if you don't like treating hyphens as part of words.
-
-Other plugins or settings like `set nocompatible` may interfere with your `iskeyword`
-setting. Be sure to load/set these before including _vim-camelsnek_ with your
-plugin manager. Try `:verbose set iskeyword?` to find these if you're having trouble.
-
-If you don't want this setting, there's a variable for that:
-
-```viml
-" Set this to prevent editing global keyword matching rules.
-" With no override:
-"   :echo &iskeyword
-"   @,48-57,_,192-255,-
-"
-" With override set to 0:
-"   :echo &iskeyword
-"   @,48-57,_,192-255
-let g:camelsnek_iskeyword_override = 0
 ```
 
 Tests

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ vim-camelsnek
 
 Convert between camel and snek case
 
-[![asciicast](https://asciinema.org/a/140650.png)](https://asciinema.org/a/140650)
+![Usage](https://user-images.githubusercontent.com/8506829/95635740-dd389100-0a52-11eb-8c25-c6b215f9fc7f.gif)
+
 
 Usage
 -----

--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ Usage
 -----
 
 ```viml
-:Snek         " converts to snake case     ('foo bar' -> 'foo_bar')
-:Camel        " converts to camel case     ('foo bar' -> 'FooBar')
-:CamelB       " converts to camelback case ('foo bar' -> 'fooBar')
-:Kebab        " converts to kebab case     ('foo bar' -> 'foo-bar')
+:Snek     " converts to snake case               ('foo bar' -> 'foo_bar')
+:Camel    " converts to camel case               ('foo bar' -> 'FooBar')
+:CamelB   " converts to camelback case           ('foo bar' -> 'fooBar')
+:Kebab    " converts to kebab case               ('foo bar' -> 'foo-bar')
+:Screm    " converts to screaming snake case     ('foo bar' -> 'FOO_BAR')
 ```
 
 These commands will function from both normal and visual mode. When in normal

--- a/README.md
+++ b/README.md
@@ -7,15 +7,20 @@ Convert between camel and snek case
 
 ![Usage](https://user-images.githubusercontent.com/8506829/95635740-dd389100-0a52-11eb-8c25-c6b215f9fc7f.gif)
 
+Installation
+------------
+
+Use your favorite plugin manager of choice, ex. [vim-plug](https://github.com/junegunn/vim-plug).
+
 Usage
 -----
 
 ```viml
-:Snek     " converts to snake case               ('foo bar' -> 'foo_bar')
-:Camel    " converts to camel case               ('foo bar' -> 'FooBar')
-:CamelB   " converts to camelback case           ('foo bar' -> 'fooBar')
-:Kebab    " converts to kebab case               ('foo bar' -> 'foo-bar')
-:Screm    " converts to screaming snake case     ('foo bar' -> 'FOO_BAR')
+:Snek     " converts to snake_case               ('foo bar' -> 'foo_bar')
+:Camel    " converts to CamelCase                ('foo bar' -> 'FooBar')
+:CamelB   " converts to camelbackCase            ('foo bar' -> 'fooBar')
+:Kebab    " converts to kebab-case               ('foo bar' -> 'foo-bar')
+:Screm    " converts to SCREAMING_SNAKE_CASE     ('foo bar' -> 'FOO_BAR')
 ```
 
 These commands will function from both normal and visual mode. When in normal
@@ -26,7 +31,7 @@ Settings
 --------
 
 ```viml
-" Some organisations use the terms camel and pascal to differentiate between
+" Some organisations use the terms Camel and Pascal to differentiate between
 " the two variants of camel case. This setting changes the commands:
 " :Camel  -> :Pascal
 " :CamelB -> :Camel
@@ -34,21 +39,22 @@ let g:camelsnek_alternative_camel_commands = 1
 
 " Are you a stick in the mud? This setting also changes the name of two commands:
 " :Snek  -> :Snake
-" :Screm -> :SnakeCaps
+" :Screm -> :Snakecaps
 let g:camelsnek_no_fun_allowed = 0
 ```
 
 ### Caveats
 
-This plugin updates your `iskeyword` global setting by default in order to make
+This plugin appends to your `iskeyword` global setting by default in order to make
 editing kebab-case easier— in normal mode with this setting, you can place your cursor
-over a kebab-case word and convert it to any other available case. This may mess
-with your existing setup if you don't like treating hyphens as part of words, and
-other plugins or settings like `set nocompatible` may interfere with it anyway.
+over a kebab-case word and convert it to any other available case. This may not be
+preferable if you don't like treating hyphens as part of words.
 
-Be sure to `set nocompatible` before loading this plugin in your `.vimrc` or this
-effect won't take place. If you *really* don't want this setting, there's a
-variable for that:
+Other plugins or settings like `set nocompatible` may interfere with your `iskeyword`
+setting. Be sure to load/set these before including _vim-camelsnek_ with your
+plugin manager. Try `:verbose set iskeyword?` to find these if you're having trouble.
+
+If you don't want this setting, there's a variable for that:
 
 ```viml
 " Set this to prevent editing global keyword matching rules.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Convert between camel and snek case
 
 ![Usage](https://user-images.githubusercontent.com/8506829/95635740-dd389100-0a52-11eb-8c25-c6b215f9fc7f.gif)
 
-
 Usage
 -----
 
@@ -37,6 +36,30 @@ let g:camelsnek_alternative_camel_commands = 1
 " :Snek  -> :Snake
 " :Screm -> :SnakeCaps
 let g:camelsnek_no_fun_allowed = 0
+```
+
+### Caveats
+
+This plugin updates your `iskeyword` global setting by default in order to make
+editing kebab-case easier— in normal mode with this setting, you can place your cursor
+over a kebab-case word and convert it to any other available case. This may mess
+with your existing setup if you don't like treating hyphens as part of words, and
+other plugins or settings like `set nocompatible` may interfere with it anyway.
+
+Be sure to `set nocompatible` before loading this plugin in your `.vimrc` or this
+effect won't take place. If you *really* don't want this setting, there's a
+variable for that:
+
+```viml
+" Set this to prevent editing global keyword matching rules.
+" With no override:
+"   :echo &iskeyword
+"   @,48-57,_,192-255,-
+"
+" With override set to 0:
+"   :echo &iskeyword
+"   @,48-57,_,192-255
+let g:camelsnek_iskeyword_override = 0
 ```
 
 Tests

--- a/autoload/camelsnek.vim
+++ b/autoload/camelsnek.vim
@@ -4,9 +4,12 @@ set cpo&vim
 
 " Library Interface: {{{1
 function! camelsnek#camel(text) abort
-  let l:text = substitute(a:text, '[^A-Za-z0-9]', ' ', 'g')
-  let l:parts = split(l:text, '\s\+')
-  let l:text = join(map(l:parts, 'toupper(v:val[0]) . v:val[1:]'), '')
+  let l:parts = split(a:text, '[^A-Za-z0-9]\+')
+  " If no delimiters can be found, it's likely already in CamelCase.
+  if len(l:parts) <= 1
+    return toupper(l:parts[0][0]) . l:parts[0][1:]
+  endif
+  let l:text = join(map(l:parts, 'toupper(v:val[0]) . tolower(v:val[1:])'), '')
   return l:text
 endfunction
 

--- a/autoload/camelsnek.vim
+++ b/autoload/camelsnek.vim
@@ -20,8 +20,7 @@ function! camelsnek#snek(text) abort
   let l:text = substitute(l:text, '\C\([^a-z]\)\([a-z]\)', ' \1\2', 'g')
   let l:text = substitute(l:text, '\C\([a-z]\)\([^a-z]\)', '\1 \2', 'g')
   let l:text = substitute(l:text, '^\s*\(.*\S\)\s*$', '\1', 'g')
-  let l:text = substitute(l:text, '\s\+', '_', 'g')
-  let l:text = substitute(l:text, '-', '_', 'g')
+  let l:text = substitute(l:text, '\(\s\+\|-\)', '_', 'g')
   return tolower(l:text)
 endfunction
 

--- a/autoload/camelsnek.vim
+++ b/autoload/camelsnek.vim
@@ -21,6 +21,7 @@ function! camelsnek#snek(text) abort
   let l:text = substitute(l:text, '\C\([a-z]\)\([^a-z]\)', '\1 \2', 'g')
   let l:text = substitute(l:text, '^\s*\(.*\S\)\s*$', '\1', 'g')
   let l:text = substitute(l:text, '\s\+', '_', 'g')
+  let l:text = substitute(l:text, '-', '_', 'g')
   return tolower(l:text)
 endfunction
 
@@ -28,6 +29,11 @@ function! camelsnek#kebab(text) abort
   let l:text = camelsnek#snek(a:text)
   let l:text = substitute(l:text, '_', '-', 'g')
   return l:text
+endfunction
+
+function! camelsnek#screm(text) abort
+  let l:text= camelsnek#snek(a:text)
+  return toupper(l:text)
 endfunction
 
 " Teardown:{{{1

--- a/autoload/camelsnek.vim
+++ b/autoload/camelsnek.vim
@@ -5,9 +5,12 @@ set cpo&vim
 " Library Interface: {{{1
 function! camelsnek#camel(text) abort
   let l:parts = split(a:text, '[^A-Za-z0-9]\+')
-  " If no delimiters can be found, it's likely already in CamelCase.
-  if len(l:parts) <= 1
+  " If list is of length 1, it's likely already in CamelCase.
+  " Otherwise, if it's less than 1, don't do anything.
+  if len(l:parts) == 1
     return toupper(l:parts[0][0]) . l:parts[0][1:]
+  elseif len(l:parts) < 1
+    return a:text
   endif
   let l:text = join(map(l:parts, 'toupper(v:val[0]) . tolower(v:val[1:])'), '')
   return l:text

--- a/plugin/camelsnek.vim
+++ b/plugin/camelsnek.vim
@@ -61,7 +61,7 @@ command! -nargs=0 -range -bar Kebab :call <SID>repl(<count>, 'kebab')
 
 if g:camelsnek_no_fun_allowed
   command! -nargs=0 -range -bar Snake :call <SID>repl(<count>, 'snek')
-  command! -nargs=0 -range -bar SnakeCaps :call <SID>repl(<count>, 'screm')
+  command! -nargs=0 -range -bar Snakecaps :call <SID>repl(<count>, 'screm')
 else
   command! -nargs=0 -range -bar Snek :call <SID>repl(<count>, 'snek')
   command! -nargs=0 -range -bar Screm :call <SID>repl(<count>, 'screm')

--- a/plugin/camelsnek.vim
+++ b/plugin/camelsnek.vim
@@ -2,6 +2,13 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
+" NOTE: this updates users' iskeyword global setting and may not be the right
+" solution. Add a file ~/.vim/after/ftplugin/camelsnek.vim with contents
+"   set iskeyword-=-
+" to remove this global change. I personally like it such that kebab can
+" change to snake case when in the middle of word, but YMMV.
+set iskeyword+=-
+
 " load guard
 " uncomment after plugin development.
 "if exists("g:loaded_camelsnek")
@@ -54,8 +61,6 @@ else
   command! -nargs=0 -range -bar Snek :call <SID>repl(<count>, 'snek')
   command! -nargs=0 -range -bar Screm :call <SID>repl(<count>, 'screm')
 endif
-
-
 
 " Teardown: {{{1
 let &cpo = s:save_cpo

--- a/plugin/camelsnek.vim
+++ b/plugin/camelsnek.vim
@@ -21,7 +21,7 @@ end
 
 " Handles iskeyword update to make kebab editing easy.
 if !exists('g:camelsnek_iskeyword_override')
-  let g:camelsnek_iskeyword_override = 1
+  let g:camelsnek_iskeyword_override = 0
 end
 
 " NOTE: this updates users' iskeyword global setting and may not be the right

--- a/plugin/camelsnek.vim
+++ b/plugin/camelsnek.vim
@@ -19,28 +19,23 @@ if !exists('g:camelsnek_no_fun_allowed')
   let g:camelsnek_no_fun_allowed = 0
 end
 
-" Handles iskeyword update to make kebab editing easy.
-if !exists('g:camelsnek_iskeyword_override')
-  let g:camelsnek_iskeyword_override = 0
-end
-
-" NOTE: this updates users' iskeyword global setting and may not be the right
-" solution, hence the override variable to remove this global change.
-" I prefer that kebab can change to snake case when in the middle of word, but YMMV.
-if g:camelsnek_iskeyword_override
-  set iskeyword+=-
-end
-
 " Private Functions: {{{1
 
 function! s:repl(count, fn) abort
   let l:s = @s
+
+  " Save iskeyword such that we can restore it later.
+  " This makes editing kebab-case much more convenient.
+  let save_iskeyword = &iskeyword
+  set iskeyword+=-
+
   if a:count < 1
     exe "norm! \"sciw\<C-R>=camelsnek#" . a:fn ."(@s)\<CR>"
   else
     exe "norm! gv\"sc\<C-R>=camelsnek#" . a:fn ."(@s)\<CR>"
   endif
   let @s = l:s
+  let &iskeyword=save_iskeyword
 endfunction
 
 " Maps: {{{1

--- a/plugin/camelsnek.vim
+++ b/plugin/camelsnek.vim
@@ -52,6 +52,7 @@ else
 endif
 
 command! -nargs=0 -range -bar Kebab :call <SID>repl(<count>, 'kebab')
+command! -nargs=0 -range -bar Screm :call <SID>repl(<count>, 'screm')
 
 
 " Teardown: {{{1

--- a/plugin/camelsnek.vim
+++ b/plugin/camelsnek.vim
@@ -15,8 +15,10 @@ if !exists('g:camelsnek_alternative_camel_commands')
   let g:camelsnek_alternative_camel_commands = 0
 end
 
-if !exists('g:camelsnek_no_fun_allowed')
+if !exists('g:camelsnek_i_am_an_old_fart_with_no_sense_of_humour_or_internet_culture') && !exists('g:camelsnek_no_fun_allowed')
   let g:camelsnek_no_fun_allowed = 0
+elseif exists('g:camelsnek_i_am_an_old_fart_with_no_sense_of_humour_or_internet_culture') && g:camelsnek_i_am_an_old_fart_with_no_sense_of_humour_or_internet_culture == 1
+  let g:camelsnek_no_fun_allowed = 1
 end
 
 " Private Functions: {{{1

--- a/plugin/camelsnek.vim
+++ b/plugin/camelsnek.vim
@@ -2,13 +2,6 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
-" NOTE: this updates users' iskeyword global setting and may not be the right
-" solution. Add a file ~/.vim/after/ftplugin/camelsnek.vim with contents
-"   set iskeyword-=-
-" to remove this global change. I personally like it such that kebab can
-" change to snake case when in the middle of word, but YMMV.
-set iskeyword+=-
-
 " load guard
 " uncomment after plugin development.
 "if exists("g:loaded_camelsnek")
@@ -24,6 +17,18 @@ end
 
 if !exists('g:camelsnek_no_fun_allowed')
   let g:camelsnek_no_fun_allowed = 0
+end
+
+" Handles iskeyword update to make kebab editing easy.
+if !exists('g:camelsnek_iskeyword_override')
+  let g:camelsnek_iskeyword_override = 1
+end
+
+" NOTE: this updates users' iskeyword global setting and may not be the right
+" solution, hence the override variable to remove this global change.
+" I prefer that kebab can change to snake case when in the middle of word, but YMMV.
+if g:camelsnek_iskeyword_override
+  set iskeyword+=-
 end
 
 " Private Functions: {{{1

--- a/plugin/camelsnek.vim
+++ b/plugin/camelsnek.vim
@@ -15,8 +15,8 @@ if !exists('g:camelsnek_alternative_camel_commands')
   let g:camelsnek_alternative_camel_commands = 0
 end
 
-if !exists('g:camelsnek_i_am_an_old_fart_with_no_sense_of_humour_or_internet_culture')
-  let g:camelsnek_i_am_an_old_fart_with_no_sense_of_humour_or_internet_culture = 0
+if !exists('g:camelsnek_no_fun_allowed')
+  let g:camelsnek_no_fun_allowed = 0
 end
 
 " Private Functions: {{{1
@@ -45,14 +45,16 @@ else
   command! -nargs=0 -range -bar CamelB :call <SID>repl(<count>, 'camelback')
 endif
 
-if g:camelsnek_i_am_an_old_fart_with_no_sense_of_humour_or_internet_culture
+command! -nargs=0 -range -bar Kebab :call <SID>repl(<count>, 'kebab')
+
+if g:camelsnek_no_fun_allowed
   command! -nargs=0 -range -bar Snake :call <SID>repl(<count>, 'snek')
+  command! -nargs=0 -range -bar SnakeCaps :call <SID>repl(<count>, 'screm')
 else
   command! -nargs=0 -range -bar Snek :call <SID>repl(<count>, 'snek')
+  command! -nargs=0 -range -bar Screm :call <SID>repl(<count>, 'screm')
 endif
 
-command! -nargs=0 -range -bar Kebab :call <SID>repl(<count>, 'kebab')
-command! -nargs=0 -range -bar Screm :call <SID>repl(<count>, 'screm')
 
 
 " Teardown: {{{1

--- a/tests/autoload/camelsnek.vim
+++ b/tests/autoload/camelsnek.vim
@@ -10,6 +10,7 @@ function! s:suite.camel() abort
   call s:assert.equal(camelsnek#camel('someCamelBackCaseText'), 'SomeCamelBackCaseText')
   call s:assert.equal(camelsnek#camel('trailing space '), 'TrailingSpace')
   call s:assert.equal(camelsnek#camel(' leading space'), 'LeadingSpace')
+  call s:assert.equal(camelsnek#camel('A_LOUD_SNEK'), 'ALoudSnek')
 endfunction
 
 function! s:suite.camelback() abort
@@ -20,6 +21,7 @@ function! s:suite.camelback() abort
   call s:assert.equal(camelsnek#camelback('someCamelBackCaseText'), 'someCamelBackCaseText')
   call s:assert.equal(camelsnek#camelback('trailing space '), 'trailingSpace')
   call s:assert.equal(camelsnek#camelback(' leading space'), 'leadingSpace')
+  call s:assert.equal(camelsnek#camelback('A_LOUD_SNEK'), 'aLoudSnek')
 endfunction
 
 function! s:suite.snek() abort
@@ -36,6 +38,7 @@ function! s:suite.snek() abort
   call s:assert.equal(camelsnek#snek('numbers 123456 are tricky'), 'numbers_123456_are_tricky')
   call s:assert.equal(camelsnek#snek('123 567 890'), '123_567_890')
   call s:assert.equal(camelsnek#snek('some-kebab-case-text'), 'some_kebab_case_text')
+  call s:assert.equal(camelsnek#snek('A_LOUD_SNEK'), 'a_loud_snek')
 endfunction
 
 function! s:suite.screm() abort
@@ -52,8 +55,8 @@ function! s:suite.screm() abort
   call s:assert.equal(camelsnek#screm('numbers 123456 are tricky'), 'NUMBERS_123456_ARE_TRICKY')
   call s:assert.equal(camelsnek#screm('123 567 890'), '123_567_890')
   call s:assert.equal(camelsnek#screm('some-kebab-case-text'), 'SOME_KEBAB_CASE_TEXT')
-  call s:assert.equal(camelsnek#screm('just_a_loud_snek'), 'JUST_A_LOUD_SNEK')
-  call s:assert.equal(camelsnek#screm('JUST_A_LOUD_SNEK'), 'JUST_A_LOUD_SNEK')
+  call s:assert.equal(camelsnek#screm('a_loud_snek'), 'A_LOUD_SNEK')
+  call s:assert.equal(camelsnek#screm('A_LOUD_SNEK'), 'A_LOUD_SNEK')
 endfunction
 
 function! s:suite.kebab() abort
@@ -70,4 +73,5 @@ function! s:suite.kebab() abort
   call s:assert.equal(camelsnek#kebab(' leading space'), 'leading-space')
   call s:assert.equal(camelsnek#kebab('numbers 123456 are tricky'), 'numbers-123456-are-tricky')
   call s:assert.equal(camelsnek#kebab('123 567 890'), '123-567-890')
+  call s:assert.equal(camelsnek#kebab('A_LOUD_SNEK'), 'a-loud-snek')
 endfunction

--- a/tests/autoload/camelsnek.vim
+++ b/tests/autoload/camelsnek.vim
@@ -53,6 +53,7 @@ function! s:suite.screm() abort
   call s:assert.equal(camelsnek#screm('123 567 890'), '123_567_890')
   call s:assert.equal(camelsnek#screm('some-kebab-case-text'), 'SOME_KEBAB_CASE_TEXT')
   call s:assert.equal(camelsnek#screm('just_a_loud_snek'), 'JUST_A_LOUD_SNEK')
+  call s:assert.equal(camelsnek#screm('JUST_A_LOUD_SNEK'), 'JUST_A_LOUD_SNEK')
 endfunction
 
 function! s:suite.kebab() abort

--- a/tests/autoload/camelsnek.vim
+++ b/tests/autoload/camelsnek.vim
@@ -35,6 +35,24 @@ function! s:suite.snek() abort
   call s:assert.equal(camelsnek#snek(' leading space'), 'leading_space')
   call s:assert.equal(camelsnek#snek('numbers 123456 are tricky'), 'numbers_123456_are_tricky')
   call s:assert.equal(camelsnek#snek('123 567 890'), '123_567_890')
+  call s:assert.equal(camelsnek#snek('some-kebab-case-text'), 'some_kebab_case_text')
+endfunction
+
+function! s:suite.screm() abort
+  call s:assert.equal(camelsnek#screm('bep'), 'BEP')
+  call s:assert.equal(camelsnek#screm('some plain text with spaces'), 'SOME_PLAIN_TEXT_WITH_SPACES')
+  call s:assert.equal(camelsnek#screm('collapse     whitespace-and    £$%&!  misc  chars'), 'COLLAPSE_WHITESPACE_AND_MISC_CHARS')
+  call s:assert.equal(camelsnek#screm('SomeCamelCaseText'), 'SOME_CAMEL_CASE_TEXT')
+  call s:assert.equal(camelsnek#screm('someCamelBackCaseText'), 'SOME_CAMEL_BACK_CASE_TEXT')
+  call s:assert.equal(camelsnek#screm('CamelTEXTWithUpperSection'), 'CAMEL_TEXT_WITH_UPPER_SECTION')
+  call s:assert.equal(camelsnek#screm('CamelWithTrailingUPPER'), 'CAMEL_WITH_TRAILING_UPPER')
+  call s:assert.equal(camelsnek#screm('CAMELWithLeadingUpper'), 'CAMEL_WITH_LEADING_UPPER')
+  call s:assert.equal(camelsnek#screm('trailing space '), 'TRAILING_SPACE')
+  call s:assert.equal(camelsnek#screm(' leading space'), 'LEADING_SPACE')
+  call s:assert.equal(camelsnek#screm('numbers 123456 are tricky'), 'NUMBERS_123456_ARE_TRICKY')
+  call s:assert.equal(camelsnek#screm('123 567 890'), '123_567_890')
+  call s:assert.equal(camelsnek#screm('some-kebab-case-text'), 'SOME_KEBAB_CASE_TEXT')
+  call s:assert.equal(camelsnek#screm('just_a_loud_snek'), 'JUST_A_LOUD_SNEK')
 endfunction
 
 function! s:suite.kebab() abort

--- a/tests/autoload/camelsnek.vim
+++ b/tests/autoload/camelsnek.vim
@@ -2,6 +2,7 @@ let s:suite = themis#suite('autoload')
 let s:assert = themis#helper('assert')
 
 function! s:suite.camel() abort
+  call s:assert.equal(camelsnek#camel('    '), '    ')
   call s:assert.equal(camelsnek#camel('noop'), 'Noop')
   call s:assert.equal(camelsnek#camel('some plain text with spaces'), 'SomePlainTextWithSpaces')
   call s:assert.equal(camelsnek#camel('collapse     whitespace-and    £$%&!  misc  chars'), 'CollapseWhitespaceAndMiscChars')
@@ -14,6 +15,7 @@ function! s:suite.camel() abort
 endfunction
 
 function! s:suite.camelback() abort
+  call s:assert.equal(camelsnek#camel('    '), '    ')
   call s:assert.equal(camelsnek#camelback('noop'), 'noop')
   call s:assert.equal(camelsnek#camelback('some plain text with spaces'), 'somePlainTextWithSpaces')
   call s:assert.equal(camelsnek#camelback('collapse     whitespace-and    £$%&!  misc  chars'), 'collapseWhitespaceAndMiscChars')

--- a/tests/plugin/camelsnek.vim
+++ b/tests/plugin/camelsnek.vim
@@ -41,16 +41,16 @@ function! s:suite.snek_word() abort
   call s:assert.equal(getline('.'), 'look_i_am_a_snek')
 endfunction
 
-function! s:suite.snek_word() abort
-  norm! ii_have_no_legs_and_i_must_screm
+function! s:suite.screm() abort
+  norm! ii_have_no_lips_and_i_must_screm
   Screm
-  call s:assert.equal(getline('.'), 'I_HAVE_NO_LEGS_AND_I_MUST_SCREM')
+  call s:assert.equal(getline('.'), 'I_HAVE_NO_LIPS_AND_I_MUST_SCREM')
 endfunction
 
-function! s:suite.snek_word() abort
-  norm! iiHaveNoLegsAndIMustScrem
+function! s:suite.screm() abort
+  norm! iiHaveNoLipsAndIMustScrem
   Screm
-  call s:assert.equal(getline('.'), 'I_HAVE_NO_LEGS_AND_I_MUST_SCREM')
+  call s:assert.equal(getline('.'), 'I_HAVE_NO_LIPS_AND_I_MUST_SCREM')
 endfunction
 
 function! s:suite.camel_word() abort

--- a/tests/plugin/camelsnek.vim
+++ b/tests/plugin/camelsnek.vim
@@ -35,6 +35,24 @@ function! s:suite.snek_word() abort
   call s:assert.equal(getline('.'), 'look_i_am_a_snek')
 endfunction
 
+function! s:suite.snek_word() abort
+  norm! ilook-i-am-a-snek
+  Snek
+  call s:assert.equal(getline('.'), 'look_i_am_a_snek')
+endfunction
+
+function! s:suite.snek_word() abort
+  norm! ii_have_no_legs_and_i_must_screm
+  Screm
+  call s:assert.equal(getline('.'), 'I_HAVE_NO_LEGS_AND_I_MUST_SCREM')
+endfunction
+
+function! s:suite.snek_word() abort
+  norm! iiHaveNoLegsAndIMustScrem
+  Screm
+  call s:assert.equal(getline('.'), 'I_HAVE_NO_LEGS_AND_I_MUST_SCREM')
+endfunction
+
 function! s:suite.camel_word() abort
   norm! ilook_i_am_a_camel
   Camel

--- a/tests/plugin/camelsnek.vim
+++ b/tests/plugin/camelsnek.vim
@@ -12,6 +12,17 @@ function! s:suite.snek() abort
 endfunction
 
 function! s:suite.camel() abort
+  exe "norm! $v^:Camel\<CR>"
+  call s:assert.equal(getline('.'), '')
+endfunction
+
+function! s:suite.camel() abort
+  norm! i
+  exe "norm! $v^:Camel\<CR>"
+  call s:assert.equal(getline('.'), ' ')
+endfunction
+
+function! s:suite.camel() abort
   norm! ithis is some text
   exe "norm! $v^:Camel\<CR>"
   call s:assert.equal(getline('.'), 'ThisIsSomeText')

--- a/tests/plugin/camelsnek.vim
+++ b/tests/plugin/camelsnek.vim
@@ -59,8 +59,20 @@ function! s:suite.camel_word() abort
   call s:assert.equal(getline('.'), 'LookIAmACamel')
 endfunction
 
+function! s:suite.camel_word() abort
+  norm! iLOOK_I_AM_A_CAMEL
+  Camel
+  call s:assert.equal(getline('.'), 'LookIAmACamel')
+endfunction
+
 function! s:suite.camelback_word() abort
   norm! ilook_i_am_a_camel
+  CamelB
+  call s:assert.equal(getline('.'), 'lookIAmACamel')
+endfunction
+
+function! s:suite.camelback_word() abort
+  norm! iLOOK_I_AM_A_CAMEL
   CamelB
   call s:assert.equal(getline('.'), 'lookIAmACamel')
 endfunction


### PR DESCRIPTION
## Preamble

First off: thank you for making this plugin! It's one of my most often used and cherished Vim plugins. There are some changes (some major, some minor) that I think may be helpful in continuing development on this plugin and, a selfish note, will benefit me daily.

All changes should be backwards-compatible, with the only main change being that kebab-case words can be converted from normal mode by default.

## Changes

### Add _SCREAMING_SNAKE_CASE_ (a.k.a. snake caps, constant case, etc.)

Adds a `Screm` command for the above. Preserves the mapping from `Snek`→`Snake` and adds `Screm`→`Snakecaps`

This is configurable via `g:camelsnek_no_fun_allowed` because the original option, though thoroughly funny, is hard to remember. This is a breaking change for any users who are old farts who have no sense of humour or internet culture, as it were.

### Add an option to parse kebab-case words in normal mode

This is something I do very often and would like to do without having to do `viw:Snek`. _(Three extra keystrokes, the horror!)_
It's configurable via the option `g:camelsnek_iskeyword_override`.

### Put a GIF in the README

Because Vim users are too ~~lazy~~ efficiency-obsessed for an extra keypress or mouse click (see above).

## Notes

There is some expanded functionality I'd like to see here but in the interest of keeping this PR somewhat tidy I'll want to open up issues for them instead.

I had also originally changed `Camel` to `Camelcaps` + `CamelB` to `Camel`, changing the alternative mapping to `Camelcaps`→`Pascal` and keeping `Camel` the same in both formats. The extra capital letter in `CamelB` was a hindrance since it requires the extra `<Shift>` keystroke; moreover I didn't seem to use it nearly as often as lowercase camelCase.

I removed the above changes since I actually really like using `Pascal` instead.